### PR TITLE
Revert "mips: fix temporarily resolving failure"

### DIFF
--- a/sid/mips/Dockerfile
+++ b/sid/mips/Dockerfile
@@ -1,7 +1,3 @@
 FROM scratch
 ADD rootfs.tar.xz /
-
-# https://omniverse.ru/blog/2016/08/25/apt-get-mips/
-RUN echo 'Acquire::ForceIPv4 "True";' > /etc/apt/apt.conf.d/80forceIPv4
-
 CMD ["/bin/bash"]

--- a/sid/mipsel/Dockerfile
+++ b/sid/mipsel/Dockerfile
@@ -1,7 +1,3 @@
 FROM scratch
 ADD rootfs.tar.xz /
-
-# https://omniverse.ru/blog/2016/08/25/apt-get-mips/
-RUN echo 'Acquire::ForceIPv4 "True";' > /etc/apt/apt.conf.d/80forceIPv4
-
 CMD ["/bin/bash"]

--- a/stretch/mips/Dockerfile
+++ b/stretch/mips/Dockerfile
@@ -1,7 +1,3 @@
 FROM scratch
 ADD rootfs.tar.xz /
-
-# https://omniverse.ru/blog/2016/08/25/apt-get-mips/
-RUN echo 'Acquire::ForceIPv4 "True";' > /etc/apt/apt.conf.d/80forceIPv4
-
 CMD ["/bin/bash"]

--- a/stretch/mipsel/Dockerfile
+++ b/stretch/mipsel/Dockerfile
@@ -1,7 +1,3 @@
 FROM scratch
 ADD rootfs.tar.xz /
-
-# https://omniverse.ru/blog/2016/08/25/apt-get-mips/
-RUN echo 'Acquire::ForceIPv4 "True";' > /etc/apt/apt.conf.d/80forceIPv4
-
 CMD ["/bin/bash"]


### PR DESCRIPTION
This has been moved into [mkimage](https://github.com/vicamo/docker/tree/mkimage) so that apt upgrade during the debootstrap stage may succeed as well.

This reverts commit 3499b9f7b6e8a37e59157a09a671463a64e8212f.