### PR TITLE
fix: map debian arm64 to linux/arm64 as docker does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           platforms='[
             ["amd64", "linux/amd64"],
             ["arm", "linux/arm"],
-            ["arm64", "linux/arm64/v8"],
+            ["arm64", "linux/arm64"],
             ["armel", "linux/arm/v5"],
             ["armhf", "linux/arm/v7"],
             ["i386", "linux/386"],


### PR DESCRIPTION
So far this doesn't cause anything wrong in this repo, but it fails to match the platforms string provided by docker buildx buider in others. To prevent confusion, update here before we bump into the same problem.