### PR TITLE
Limit max-parallel of per-suite task to 4

### DIFF
--- a/.github/workflows/per-suite.yml
+++ b/.github/workflows/per-suite.yml
@@ -53,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         include: ${{ fromJSON(inputs.architectures) }}
     env:


### PR DESCRIPTION
In the hope to prevent following intermittent [errors](https://github.com/vicamo/docker-brew-debian/actions/runs/12971096483/job/36177121188):
```
+ wget -O /tmp/debuerreotype.sid.2wg1ZPx2tI/output/20250125/sh4/sid/InRelease http://snapshot.debian.org/archive/debian-ports/20250125T033450Z/dists/sid/InRelease
--2025-01-26 03:34:56--  http://snapshot.debian.org/archive/debian-ports/20250125T033450Z/dists/sid/InRelease
Resolving snapshot.debian.org (snapshot.debian.org)... 146.75.30.132, 2a04:4e42:77::644
Connecting to snapshot.debian.org (snapshot.debian.org)|146.75.30.132|:80... connected.
HTTP request sent, awaiting response... 503 first byte timeout
2025-01-26 03:35:12 ERROR 503: first byte timeout.

+ '[' -f /tmp/debuerreotype.sid.2wg1ZPx2tI/debian-archive-sid-keyring.gpg ']'
+ wget -O /tmp/debuerreotype.sid.2wg1ZPx2tI/output/20250125/sh4/sid/Release.gpg http://snapshot.debian.org/archive/debian-ports/20250125T033450Z/dists/sid/Release.gpg
--2025-01-26 03:35:12--  http://snapshot.debian.org/archive/debian-ports/20250125T033450Z/dists/sid/Release.gpg
Resolving snapshot.debian.org (snapshot.debian.org)... 146.75.30.132, 2a04:4e42:77::644
Connecting to snapshot.debian.org (snapshot.debian.org)|146.75.30.132|:80... connected.
HTTP request sent, awaiting response... 503 first byte timeout
2025-01-26 03:35:28 ERROR 503: first byte timeout.

+ '[' sid = slink ']'
+ echo 'error: failed to fetch either InRelease or Release.gpg+Release for '\''sid'\'' (from '\''http://snapshot.debian.org/archive/debian-ports/20250125T033450Z'\'')'
error: failed to fetch either InRelease or Release.gpg+Release for 'sid' (from 'http://snapshot.debian.org/archive/debian-ports/20250125T033450Z')
+ exit 1
```